### PR TITLE
Save URL slugs for attribute values

### DIFF
--- a/app/code/community/Emico/TweakwiseExport/Model/Observer/UrlMapping.php
+++ b/app/code/community/Emico/TweakwiseExport/Model/Observer/UrlMapping.php
@@ -8,8 +8,6 @@
  */
 class Emico_TweakwiseExport_Model_Observer_UrlMapping
 {
-    const SLUG_MAPPING_TABLE = 'emico_tweakwise_slug_attribute_mapping';
-
     /**
      * @var array
      */
@@ -53,10 +51,6 @@ class Emico_TweakwiseExport_Model_Observer_UrlMapping
             return;
         }
 
-        $connection = Mage::getSingleton('core/resource')->getConnection('core_write');
-
-        $connection->truncateTable(self::SLUG_MAPPING_TABLE);
-
         $rowsToInsert = [];
         foreach ($this->attributesExported as $code => $values) {
             /** @var array $values */
@@ -70,10 +64,7 @@ class Emico_TweakwiseExport_Model_Observer_UrlMapping
             }
         }
 
-        $connection->insertMultiple(self::SLUG_MAPPING_TABLE, $rowsToInsert);
-
-        // Clear the collection cache
-        Mage::getModel('emico_tweakwise/slugAttributeMapping')->clearCache();
+        Mage::getModel('emico_tweakwiseexport/slugAttributeMapping')->insertBatch($rowsToInsert);
     }
 
     /**

--- a/app/code/community/Emico/TweakwiseExport/Model/Observer/UrlMapping.php
+++ b/app/code/community/Emico/TweakwiseExport/Model/Observer/UrlMapping.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @copyright (c) Emico 2015
+ */
+
+/**
+ * Class Emico_TweakwiseExport_Model_Observer_UrlMapping
+ */
+class Emico_TweakwiseExport_Model_Observer_UrlMapping
+{
+    const SLUG_MAPPING_TABLE = 'emico_tweakwise_slug_attribute_mapping';
+
+    /**
+     * @var array
+     */
+    protected $attributesExported = [];
+
+    /**
+     * Register all uniquely exported attribute codes and values, so we can persist them at the end of the export
+     *
+     * @param Varien_Event_Observer $observer
+     */
+    public function addProductAttributes(Varien_Event_Observer $observer)
+    {
+        //if (!Mage::helper('emico_tweakwise/uriStrategy')->hasActiveStrategy('path')) {
+        //    return;
+        //}
+
+        /** @var array $exportAttributes */
+        $exportAttributes = $observer->getData('exportAttributes');
+
+        foreach ($exportAttributes as $code => $values) {
+            if (!isset($this->attributesExported[$code])) {
+                $this->attributesExported[$code] = [];
+            }
+            $this->attributesExported[$code] = array_unique(
+                array_merge(
+                    $this->attributesExported[$code],
+                    $values
+                )
+            );
+        }
+    }
+
+    /**
+     * Flush slugs for all exported attributes
+     *
+     * @param Varien_Event_Observer $observer
+     */
+    public function writeAttributeSlugs(Varien_Event_Observer $observer)
+    {
+        //if (!Mage::helper('emico_tweakwise/uriStrategy')->hasActiveStrategy('path')) {
+        //    return;
+        //}
+
+        $connection = Mage::getSingleton('core/resource')->getConnection('core_write');
+
+        $connection->truncateTable(self::SLUG_MAPPING_TABLE);
+
+        $rowsToInsert = [];
+        foreach ($this->attributesExported as $code => $values) {
+            /** @var array $values */
+            foreach ($values as $value) {
+
+                $rowsToInsert[] = [
+                    'attribute_code' => $code,
+                    'attribute_value' => $value,
+                    'slug' => $this->getSlugifier()->slugify($value)
+                ];
+            }
+        }
+
+        $connection->insertMultiple(self::SLUG_MAPPING_TABLE, $rowsToInsert);
+
+        // Clear the collection cache
+        Mage::getModel('emico_tweakwise/slugAttributeMapping')->clearCache();
+    }
+
+    /**
+     * @return Emico_Tweakwise_Helper_Slugifier
+     */
+    protected function getSlugifier()
+    {
+        return Mage::helper('emico_tweakwise/slugifier');
+    }
+}

--- a/app/code/community/Emico/TweakwiseExport/Model/Observer/UrlMapping.php
+++ b/app/code/community/Emico/TweakwiseExport/Model/Observer/UrlMapping.php
@@ -20,10 +20,6 @@ class Emico_TweakwiseExport_Model_Observer_UrlMapping
      */
     public function addProductAttributes(Varien_Event_Observer $observer)
     {
-        if (!Mage::helper('emico_tweakwise/uriStrategy')->hasActiveStrategy('path')) {
-            return;
-        }
-
         /** @var array $exportAttributes */
         $exportAttributes = $observer->getData('exportAttributes');
 
@@ -47,10 +43,6 @@ class Emico_TweakwiseExport_Model_Observer_UrlMapping
      */
     public function writeAttributeSlugs(Varien_Event_Observer $observer)
     {
-        if (!Mage::helper('emico_tweakwise/uriStrategy')->hasActiveStrategy('path')) {
-            return;
-        }
-
         $rowsToInsert = [];
         foreach ($this->attributesExported as $code => $values) {
             /** @var array $values */

--- a/app/code/community/Emico/TweakwiseExport/Model/Observer/UrlMapping.php
+++ b/app/code/community/Emico/TweakwiseExport/Model/Observer/UrlMapping.php
@@ -22,9 +22,9 @@ class Emico_TweakwiseExport_Model_Observer_UrlMapping
      */
     public function addProductAttributes(Varien_Event_Observer $observer)
     {
-        //if (!Mage::helper('emico_tweakwise/uriStrategy')->hasActiveStrategy('path')) {
-        //    return;
-        //}
+        if (!Mage::helper('emico_tweakwise/uriStrategy')->hasActiveStrategy('path')) {
+            return;
+        }
 
         /** @var array $exportAttributes */
         $exportAttributes = $observer->getData('exportAttributes');
@@ -49,9 +49,9 @@ class Emico_TweakwiseExport_Model_Observer_UrlMapping
      */
     public function writeAttributeSlugs(Varien_Event_Observer $observer)
     {
-        //if (!Mage::helper('emico_tweakwise/uriStrategy')->hasActiveStrategy('path')) {
-        //    return;
-        //}
+        if (!Mage::helper('emico_tweakwise/uriStrategy')->hasActiveStrategy('path')) {
+            return;
+        }
 
         $connection = Mage::getSingleton('core/resource')->getConnection('core_write');
 

--- a/app/code/community/Emico/TweakwiseExport/Model/Resource/SlugAttributeMapping.php
+++ b/app/code/community/Emico/TweakwiseExport/Model/Resource/SlugAttributeMapping.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @author Bram Gerritsen <bgerritsen@emico.nl>
+ * @copyright (c) Emico B.V. 2017
+ */ 
+class Emico_TweakwiseExport_Model_Resource_SlugAttributeMapping extends Mage_Core_Model_Resource_Db_Abstract
+{
+
+    protected function _construct()
+    {
+        $this->_init('emico_tweakwiseexport/slug_attribute_mapping', 'mapping_id');
+    }
+
+    /**
+     * @param array $records
+     * @return int Number of affected rows
+     */
+    public function truncateAndinsertBatch(array $records)
+    {
+        $mainTable = $this->getMainTable();
+        $this->_getWriteAdapter()->truncateTable($mainTable);
+        return $this->_getWriteAdapter()->insertMultiple($mainTable, $records);
+    }
+}

--- a/app/code/community/Emico/TweakwiseExport/Model/Resource/SlugAttributeMapping/Collection.php
+++ b/app/code/community/Emico/TweakwiseExport/Model/Resource/SlugAttributeMapping/Collection.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @author Bram Gerritsen <bgerritsen@emico.nl>
+ * @copyright (c) Emico B.V. 2017
+ */ 
+class Emico_TweakwiseExport_Model_Resource_SlugAttributeMapping_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
+{
+
+    protected function _construct()
+    {
+        $this->_init('emico_tweakwiseexport/slugAttributeMapping');
+    }
+
+}

--- a/app/code/community/Emico/TweakwiseExport/Model/SlugAttributeMapping.php
+++ b/app/code/community/Emico/TweakwiseExport/Model/SlugAttributeMapping.php
@@ -30,7 +30,7 @@ class Emico_TweakwiseExport_Model_SlugAttributeMapping extends Mage_Core_Model_A
 
         // Clear the collection cache
         if ($affectedRows > 0) {
-            Mage::getModel('emico_tweakwise/slugAttributeMapping')->clearCache();
+            $this->clearCache();
         }
     }
 

--- a/app/code/community/Emico/TweakwiseExport/Model/SlugAttributeMapping.php
+++ b/app/code/community/Emico/TweakwiseExport/Model/SlugAttributeMapping.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * @author Bram Gerritsen <bgerritsen@emico.nl>
+ * @copyright (c) Emico B.V. 2017
+ */ 
+class Emico_TweakwiseExport_Model_SlugAttributeMapping extends Mage_Core_Model_Abstract
+{
+    /**
+     * @var
+     */
+    protected $mapping;
+
+    /**
+     * Default constructor
+     */
+    protected function _construct()
+    {
+        $this->_init('emico_tweakwiseexport/slugAttributeMapping');
+    }
+
+    /**
+     * @param array $records
+     */
+    public function insertBatch(array $records)
+    {
+        /** @var Emico_TweakwiseExport_Model_Resource_SlugAttributeMapping $resource */
+        $resource = $this->getResource();
+
+        $affectedRows = $resource->truncateAndinsertBatch($records);
+
+        // Clear the collection cache
+        if ($affectedRows > 0) {
+            Mage::getModel('emico_tweakwise/slugAttributeMapping')->clearCache();
+        }
+    }
+
+    /**
+     * @param $code
+     * @param $value
+     * @return string
+     */
+    public function getSlugForAttribute($code, $value)
+    {
+        $mapping = $this->getMapping();
+        if (!isset($mapping[$code][$value])) {
+            return $value;
+        }
+        return $mapping[$code][$value];
+    }
+
+    /**
+     * @param string $code
+     * @param string $requestedSlug
+     * @return int|null|string
+     * @throws Emico_TweakwiseExport_Model_Exception
+     */
+    public function getAttributeValueBySlug($code, $requestedSlug)
+    {
+        $mapping = $this->getMapping();
+        if (!isset($mapping[$code])) {
+            throw new Emico_TweakwiseExport_Model_Exception('No slugs defined for attributeCode ' . $code);
+        }
+        $attributeSlugs = $mapping[$code];
+        foreach ($attributeSlugs as $attributeValue => $slug) {
+            if ($requestedSlug === $slug) {
+                return $attributeValue;
+            }
+        }
+        throw new Emico_TweakwiseExport_Model_Exception(sprintf('No slug found for attributeCode "%s" and slug "%s"', $code, $requestedSlug));
+    }
+
+    /**
+     * @return bool
+     */
+    public function clearCache()
+    {
+        return $this->getCacheInstance()->remove($this->getCollection()->getCacheKey());
+    }
+
+    /**
+     * @return Zend_Cache_Core
+     */
+    protected function getCacheInstance()
+    {
+        return Mage::app()->getCache();
+    }
+
+    /**
+     * @return array
+     */
+    protected function getMapping()
+    {
+        if ($this->mapping === null) {
+
+            $this->getCollection()->initCache(
+                $this->getCacheInstance(),
+                null,
+                ['collections', 'tweakwise_slugs']
+            );
+
+            $collection = $this->getCollection()->load();
+            foreach ($collection as $item) {
+                $this->mapping[$item->getAttributeCode()][$item->getAttributeValue()] = $item->getSlug();
+            }
+        }
+        return $this->mapping;
+    }
+
+}

--- a/app/code/community/Emico/TweakwiseExport/Model/Writer/Productiterator.php
+++ b/app/code/community/Emico/TweakwiseExport/Model/Writer/Productiterator.php
@@ -37,9 +37,9 @@ class Emico_TweakwiseExport_Model_Writer_Productiterator implements IteratorAggr
             $initialEnvironmentInfo = $appEmulation->startEnvironmentEmulation($store->getId());
 
             $iterator->append($this->getSimpleIterator($store));
-            //$iterator->append($this->getBundledIterator($store));
-            //$iterator->append($this->getConfigurableIterator($store));
-            //$iterator->append($this->getGroupedIterator($store));
+            $iterator->append($this->getBundledIterator($store));
+            $iterator->append($this->getConfigurableIterator($store));
+            $iterator->append($this->getGroupedIterator($store));
 
             Mage::dispatchEvent('emico_tweakwiseexport_prepare_product_collection', [
                 'collection' => $iterator,
@@ -97,7 +97,6 @@ class Emico_TweakwiseExport_Model_Writer_Productiterator implements IteratorAggr
             }
         }
         $select->where('e.type_id NOT IN(\'bundle\', \'configurable\', \'grouped\')');
-        $select->limit(10);
         $this->addDefaultColumns($select);
 
         /** @var Varien_Db_Statement_Pdo_Mysql $stmt */

--- a/app/code/community/Emico/TweakwiseExport/Model/Writer/Productiterator.php
+++ b/app/code/community/Emico/TweakwiseExport/Model/Writer/Productiterator.php
@@ -37,9 +37,9 @@ class Emico_TweakwiseExport_Model_Writer_Productiterator implements IteratorAggr
             $initialEnvironmentInfo = $appEmulation->startEnvironmentEmulation($store->getId());
 
             $iterator->append($this->getSimpleIterator($store));
-            $iterator->append($this->getBundledIterator($store));
-            $iterator->append($this->getConfigurableIterator($store));
-            $iterator->append($this->getGroupedIterator($store));
+            //$iterator->append($this->getBundledIterator($store));
+            //$iterator->append($this->getConfigurableIterator($store));
+            //$iterator->append($this->getGroupedIterator($store));
 
             Mage::dispatchEvent('emico_tweakwiseexport_prepare_product_collection', [
                 'collection' => $iterator,
@@ -97,6 +97,7 @@ class Emico_TweakwiseExport_Model_Writer_Productiterator implements IteratorAggr
             }
         }
         $select->where('e.type_id NOT IN(\'bundle\', \'configurable\', \'grouped\')');
+        $select->limit(10);
         $this->addDefaultColumns($select);
 
         /** @var Varien_Db_Statement_Pdo_Mysql $stmt */

--- a/app/code/community/Emico/TweakwiseExport/Model/Writer/Writer.php
+++ b/app/code/community/Emico/TweakwiseExport/Model/Writer/Writer.php
@@ -153,6 +153,7 @@ class Emico_TweakwiseExport_Model_Writer_Writer
             }
 
             $writtenAttributeValues = [];
+            $exportedAttributesValues = [];
             foreach ($product as $attributeCode => $values) {
                 if ($values === null) {
                     continue;
@@ -180,6 +181,7 @@ class Emico_TweakwiseExport_Model_Writer_Writer
                     }
 
                     $writtenAttributeValues[$attributeCode . $value] = true;
+                    $exportedAttributesValues[$attributeCode][] = $value;
                     $writer->writeAttribute($attributeCode, $value);
                 }
             }
@@ -191,6 +193,7 @@ class Emico_TweakwiseExport_Model_Writer_Writer
                 [
                     'product' => $product,
                     'writer' => $writer,
+                    'exportAttributes' => $exportedAttributesValues
                 ]
             );
 

--- a/app/code/community/Emico/TweakwiseExport/etc/config.xml
+++ b/app/code/community/Emico/TweakwiseExport/etc/config.xml
@@ -39,12 +39,24 @@
                     </emico_tweakwiseexport>
                 </observers>
             </emico_tweakwiseexport_before_copy_feed>
+            <emico_tweakwiseexport_after_export>
+                <observers>
+                    <emico_tweakwiseexport>
+                        <class>emico_tweakwiseexport/observer_urlMapping</class>
+                        <method>writeAttributeSlugs</method>
+                    </emico_tweakwiseexport>
+                </observers>
+            </emico_tweakwiseexport_after_export>
             <emico_tweakwiseexport_product_export_attributes_after>
                 <observers>
                     <emico_tweakwiseexport>
                         <class>emico_tweakwiseexport/observer</class>
                         <method>addNotExportedAttributes</method>
                     </emico_tweakwiseexport>
+                    <emico_tweakwiseexport_urlmapping>
+                        <class>emico_tweakwiseexport/observer_urlMapping</class>
+                        <method>addProductAttributes</method>
+                    </emico_tweakwiseexport_urlmapping>
                 </observers>
             </emico_tweakwiseexport_product_export_attributes_after>
         </events>

--- a/app/code/community/Emico/TweakwiseExport/etc/config.xml
+++ b/app/code/community/Emico/TweakwiseExport/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Emico_TweakwiseExport>
-            <version>2.2.1</version>
+            <version>2.3.0</version>
         </Emico_TweakwiseExport>
     </modules>
     <global>
@@ -14,7 +14,16 @@
         <models>
             <emico_tweakwiseexport>
                 <class>Emico_TweakwiseExport_Model</class>
+                <resourceModel>emico_tweakwiseexport_resource</resourceModel>
             </emico_tweakwiseexport>
+            <emico_tweakwiseexport_resource>
+                <class>Emico_TweakwiseExport_Model_Resource</class>
+                <entities>
+                    <slug_attribute_mapping>
+                        <table>emico_tweakwiseexport_slug_attribute_mapping</table>
+                    </slug_attribute_mapping>
+                </entities>
+            </emico_tweakwiseexport_resource>
         </models>
         <helpers>
             <emico_tweakwiseexport>
@@ -30,27 +39,23 @@
                     </emico_tweakwiseexport>
                 </observers>
             </emico_tweakwiseexport_before_copy_feed>
-            <emico_tweakwiseexport_after_export>
-                <observers>
-                    <emico_tweakwiseexport>
-                        <class>emico_tweakwiseexport/observer_urlMapping</class>
-                        <method>writeAttributeSlugs</method>
-                    </emico_tweakwiseexport>
-                </observers>
-            </emico_tweakwiseexport_after_export>
             <emico_tweakwiseexport_product_export_attributes_after>
                 <observers>
                     <emico_tweakwiseexport>
                         <class>emico_tweakwiseexport/observer</class>
                         <method>addNotExportedAttributes</method>
                     </emico_tweakwiseexport>
-                    <emico_tweakwiseexport_urlmapping>
-                        <class>emico_tweakwiseexport/observer_urlMapping</class>
-                        <method>addProductAttributes</method>
-                    </emico_tweakwiseexport_urlmapping>
                 </observers>
             </emico_tweakwiseexport_product_export_attributes_after>
         </events>
+        <resources>
+            <emico_tweakwiseexport_setup>
+                <setup>
+                    <module>Emico_TweakwiseExport</module>
+                    <class>Mage_Catalog_Model_Resource_Eav_Mysql4_Setup</class>
+                </setup>
+            </emico_tweakwiseexport_setup>
+        </resources>
     </global>
     <frontend>
         <routers>

--- a/app/code/community/Emico/TweakwiseExport/etc/config.xml
+++ b/app/code/community/Emico/TweakwiseExport/etc/config.xml
@@ -30,12 +30,24 @@
                     </emico_tweakwiseexport>
                 </observers>
             </emico_tweakwiseexport_before_copy_feed>
+            <emico_tweakwiseexport_after_export>
+                <observers>
+                    <emico_tweakwiseexport>
+                        <class>emico_tweakwiseexport/observer_urlMapping</class>
+                        <method>writeAttributeSlugs</method>
+                    </emico_tweakwiseexport>
+                </observers>
+            </emico_tweakwiseexport_after_export>
             <emico_tweakwiseexport_product_export_attributes_after>
                 <observers>
                     <emico_tweakwiseexport>
                         <class>emico_tweakwiseexport/observer</class>
                         <method>addNotExportedAttributes</method>
                     </emico_tweakwiseexport>
+                    <emico_tweakwiseexport_urlmapping>
+                        <class>emico_tweakwiseexport/observer_urlMapping</class>
+                        <method>addProductAttributes</method>
+                    </emico_tweakwiseexport_urlmapping>
                 </observers>
             </emico_tweakwiseexport_product_export_attributes_after>
         </events>

--- a/app/code/community/Emico/TweakwiseExport/sql/emico_tweakwiseexport_setup/mysql4-upgrade-2.2.1-2.3.0.php
+++ b/app/code/community/Emico/TweakwiseExport/sql/emico_tweakwiseexport_setup/mysql4-upgrade-2.2.1-2.3.0.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @author : Bram Gerritsen, email: bgerritsen@emico.nl.
+ * @copyright : Copyright Emico B.V. 2018.
+ */
+/** @var Mage_Catalog_Model_Resource_Eav_Mysql4_Setup $installer */
+$installer = $this;
+$installer->startSetup();
+
+$table = $installer->getConnection()
+    ->newTable($installer->getTable('emico_tweakwiseexport/slug_attribute_mapping'))
+    ->addColumn(
+        'mapping_id', Varien_Db_Ddl_Table::TYPE_INTEGER, null,
+        array(
+            'identity' => true,
+            'unsigned' => true,
+            'nullable' => false,
+            'primary'  => true,
+        ), 'Unique identifier'
+    )
+    ->addColumn(
+        'slug', Varien_Db_Ddl_Table::TYPE_VARCHAR, 255, array(), 'URL slug'
+    )
+    ->addColumn(
+        'attribute_code', Varien_Db_Ddl_Table::TYPE_VARCHAR, 255, array(), 'Attribute code in tweakwise'
+    )->addColumn(
+        'attribute_value', Varien_Db_Ddl_Table::TYPE_VARCHAR, 255, array(), 'Attribute value in tweakwise'
+    );
+
+if (!$installer->getConnection()->isTableExists($table->getName())) {
+    $installer->getConnection()->createTable($table);
+}
+
+$installer->endSetup();


### PR DESCRIPTION
Opslaan van URL slugs van de attribuut waarden tijdens de TweakWise export.
Deze moeten vastgelegd worden om bij het afhandelen van een SEO friendly URL een lookup te kunnen doen voor het juiste tweakwise attribuut.
Het creeren van een slug is een one way operatie, dus we moeten hier een administratie van bijhouden.