### PR TITLE
Make child class compatible with the parent

### DIFF
--- a/app/code/community/Emico/TweakwiseExport/Model/Writer/Xml.php
+++ b/app/code/community/Emico/TweakwiseExport/Model/Writer/Xml.php
@@ -103,9 +103,9 @@ class Emico_TweakwiseExport_Model_Writer_Xml extends XMLWriter
     /**
      * @return void
      */
-    public function flush()
+    public function flush($empty = true)
     {
-        fwrite($this->handle, parent::flush());
+        fwrite($this->handle, parent::flush($empty));
     }
 
     /**


### PR DESCRIPTION
The method flush did not have the same signature as the one on the
parent class. This was creating a warning.

Here is a sample warning message:

Warning: Declaration of Emico_TweakwiseExport_Model_Writer_Xml::flush() should be compatible with XMLWriter::flush($empty = NULL)  in .../app/code/community/Emico/TweakwiseExport/Model/Writer/Xml.php on line 0