### PR TITLE
Load abstract file next to the tweakwise file

### DIFF
--- a/shell/tweakwise.php
+++ b/shell/tweakwise.php
@@ -3,8 +3,9 @@
  * @copyright (c) Emico 2015
  */
 
-if (file_exists('abstract.php')) {
-    require_once 'abstract.php';
+$abstractFile = dirname(__FILE__).'/abstract.php';
+if (file_exists($abstractFile)) {
+    require_once $abstractFile;
 } else {
     require_once __DIR__ . '/../../../../shell/abstract.php';
 }


### PR DESCRIPTION
`__FILE__` always returns current script
the `dirname(__FILE__)` will result in `public_html/shell` 
So with `require_once dirname(__FILE__).'/abstract.php';` 
it will look for the abstract file next to the `tweakwise.php` file and then try the `/../../../../shell/abstract.php` file